### PR TITLE
fix: added missing tests and found bugs...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,9 @@ export const isLastWeek = d =>
 export const monthRange = (s, e, f) =>
   rangeImpl(s, e + 1, 1, f);
 
-export const rangeInMonth = (d, s, e, f) => {
+export const rangeInMonth = (d, e, f) => {
   const em = endOfMonth(d);
-  return rangeImpl(d.getDate(),
-                   Math.min(e + 1, em.getDate()), 1, f);
+  return rangeImpl(d.getDate(), Math.min(e + 1, em.getDate() + 1), 1, f);
 };
 
 export const beginOfMonth = d =>
@@ -116,7 +115,7 @@ export function weekCImpl(d, f) {
   if (isFirstWeek(d) && (day - weekday) != 1) {
     const eopm = endOfPreviousMonth(d);
     const proxyDate = applyWithYearAndMonth(f, eopm);
-    return lastWeekOfMonth(eom, proxyDate).concat(
+    return lastWeekOfMonth(eopm, proxyDate).concat(
       firstWeekOfMonth(d, proxyCurrentDate)
     );
   }

--- a/tests/weeks.js
+++ b/tests/weeks.js
@@ -5,6 +5,30 @@ import { rangeIncl } from 'js-sdk-range';
 import * as C from '../src/index.js';
 
 export default () => {
+  context("simple ranges", () => {
+    context("generates a range limiting by the last day of the month.", () => {
+      it("stop at the last day.", () => {
+        const A = new Date(2017, 0, 25);
+        C.rangeInMonth(A, 32, x => x).should.be.eql([25, 26, 27, 28, 29, 30, 31]);
+      });
+
+      it("from the begging of the month.", () => {
+        const A = new Date(2017, 0, 1);
+        C.rangeInMonth(A, 2, x => x).should.be.eql([1, 2]);
+      });
+    });
+
+    it("with date in january, get the first week of the next month.", () => {
+      const A = new Date(2017, 1, 1);
+      C.firstWeekOfNextMonth(A, x => x).should.be.eql([1, 2, 3, 4]);
+    });
+
+    it("with date in march, get the last week of the previous month.", () => {
+      const A = new Date(2017, 2, 1);
+      C.lastWeekOfPreviousMonth(A, x => x).should.be.eql([26, 27, 28]);
+    });
+  });
+
   context("non-continuous", () => {
     it("first week of october 2017", () => {
       const A = new Date(2017, 9, 1);
@@ -56,6 +80,20 @@ export default () => {
     it("last week of february 2017.", () => {
       const A = new Date(2017, 2, 0);
       C.weekC(A).should.be.eql([
+        [2017, 1, 26],
+        [2017, 1, 27],
+        [2017, 1, 28],
+        [2017, 2,  1],
+        [2017, 2,  2],
+        [2017, 2,  3],
+        [2017, 2,  4]
+      ]);
+    });
+
+    it("use weekCImpl to apply a function for each date.", () => {
+      const A = new Date(2017, 2, 1);
+      const makeDate = (y, m, d) => [y, m, d];
+      C.weekCImpl(A, makeDate).should.be.eql([
         [2017, 1, 26],
         [2017, 1, 27],
         [2017, 1, 28],


### PR DESCRIPTION
this is why tests can help people...

`rangeInMonth` uses `rangeImpl` which requires +1
when getting the last date for the range correctly.

`weekCImpl` was using the last day of the current month,
not of the previous one.

closes #6.